### PR TITLE
add disable shortcode attr and filter, add submit id

### DIFF
--- a/paylane/wp_paylane_plugin/wp_paylane_plugin.php
+++ b/paylane/wp_paylane_plugin/wp_paylane_plugin.php
@@ -258,7 +258,7 @@ function wp_paylane_plugin_shortcodes($attributes)
 {
 	$attributes = shortcode_atts(
 		array(
-			'disabled' => 'enabled'
+			'disabled' => ''
 		), $attributes, 'paylane_plugin' );
 
 	return wp_paylane_plugin_display($attributes);
@@ -532,11 +532,17 @@ function wp_paylane_plugin_display($attributes)
 	$disabled = $attributes['disabled'];
 	$enabled_filter = apply_filters('wp_paylane_enabled_pay_button', -1);
 	if(is_bool($enabled_filter)) {
-		if ( !$enabled_filter ) {
+		if (!$enabled_filter) {
 			$disabled = 'disabled';
 		} else {
-			$disabled = 'enabled';
+			$disabled = '';
 		}
+	}
+
+	if ($disabled === 'disabled') {
+		$disabled = 'disabled="disabled"';
+	} else {
+		$disabled = '';
 	}
 	
 	$was_redirected = false;
@@ -576,7 +582,7 @@ function wp_paylane_plugin_display($attributes)
 			<input type=\"hidden\" name=\"transaction_description\" value=\"" . htmlspecialchars($transaction_description) . "\"/>
 			<input type=\"hidden\" name=\"language\" value=\"en\"/>
 			<input type=\"hidden\" name=\"hash\" value=\"$shash\"/>
-			<input type=\"submit\" class=\"wp_paylane_pay_button\" value=\"$button_text\" disabled=\"$disabled\" />
+			<input type=\"submit\" class=\"wp_paylane_pay_button\" value=\"$button_text\" $disabled />
 		</form></div><br/>";
 	
 	return $output;

--- a/paylane/wp_paylane_plugin/wp_paylane_plugin.php
+++ b/paylane/wp_paylane_plugin/wp_paylane_plugin.php
@@ -256,7 +256,12 @@ function wp_paylane_plugin_options_validate_notification_email($input)
  */
 function wp_paylane_plugin_shortcodes($attributes)
 {
-	return wp_paylane_plugin_display();
+	$attributes = shortcode_atts(
+		array(
+			'disabled' => 'enabled'
+		), $attributes, 'paylane_plugin' );
+
+	return wp_paylane_plugin_display($attributes);
 }
 
 /**
@@ -499,7 +504,7 @@ function wp_paylane_plugin_check_postback_status()
  * 
  * @return string html code
  */
-function wp_paylane_plugin_display()
+function wp_paylane_plugin_display($attributes)
 {
 	$output = "";
 	
@@ -523,6 +528,16 @@ function wp_paylane_plugin_display()
 	$transaction_description = get_option('wp_paylane_plugin_transaction_description');
 	$button_text = get_option('wp_paylane_plugin_button_text');
 	$shash = sha1($hash_salt . "|" . $my_merchant_transaction_id . "|" . $my_amount . "|" . $my_currency_code . "|S");
+
+	$disabled = $attributes['disabled'];
+	$enabled_filter = apply_filters('wp_paylane_enabled_pay_button', -1);
+	if(is_bool($enabled_filter)) {
+		if ( !$enabled_filter ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = 'enabled';
+		}
+	}
 	
 	$was_redirected = false;
 	$is_successful = false;
@@ -561,7 +576,7 @@ function wp_paylane_plugin_display()
 			<input type=\"hidden\" name=\"transaction_description\" value=\"" . htmlspecialchars($transaction_description) . "\"/>
 			<input type=\"hidden\" name=\"language\" value=\"en\"/>
 			<input type=\"hidden\" name=\"hash\" value=\"$shash\"/>
-			<input type=\"submit\" value=\"$button_text\"/>
+			<input type=\"submit\" class=\"wp_paylane_pay_button\" value=\"$button_text\" disabled=\"$disabled\" />
 		</form></div><br/>";
 	
 	return $output;


### PR DESCRIPTION
- add a possibility to disable submit button by default via shortcode attribute `disable=disable` e.g. when we want to enable it via java script `[paylane_plugin disabled=disabled]`
- add a filter to disable/enable submit button via functions.php or custom plugin
- add css class `wp_paylane_pay_button` to easy get input in javascript
